### PR TITLE
Jspaaks citationcff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,6 +16,6 @@ authors:
   affiliation: Leiden University Medical Center
   orcid: https://orcid.org/0000-0002-1215-167X
 version: '0.5'
-date-released: '2017-12-05'
+date-released: 2017-12-05
 repository-code: https://github.com/NLeSC/ODEX-FAIRDataPoint
 license: Apache-2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,21 +1,22 @@
 # YAML 1.2
 # Metadata for citation of this software according to the CFF format (https://citation-file-format.github.io/)
-cff-version: 1.0.3
-message: If you use this software, please cite it as below.
-# FIXME title as repository name might not be the best name, please make human readable
-title: FAIR Data Point
-doi: 10.5281/zenodo.1083951
-# FIXME splitting of full names is error prone, please check if given/family name are correct
-authors:
-- given-names: Arnold
-  family-names: Kuzniar
-  affiliation: Netherlands eScience Center
-  orcid: https://orcid.org/0000-0003-1711-7961
-- given-names: Rajaram
-  family-names: Kaliyaperumal
-  affiliation: Leiden University Medical Center
-  orcid: https://orcid.org/0000-0002-1215-167X
-version: '0.5'
+--- 
+authors: 
+  - 
+    affiliation: "Netherlands eScience Center"
+    family-names: Kuzniar
+    given-names: Arnold
+    orcid: "https://orcid.org/0000-0003-1711-7961"
+  - 
+    affiliation: "Leiden University Medical Center"
+    family-names: Kaliyaperumal
+    given-names: Rajaram
+    orcid: "https://orcid.org/0000-0002-1215-167X"
+cff-version: "1.0.3"
 date-released: 2017-12-05
-repository-code: https://github.com/NLeSC/ODEX-FAIRDataPoint
+doi: 10.5281/zenodo.1083951
 license: Apache-2.0
+message: "If you use this software, please cite it using these metadata."
+repository-code: "https://github.com/NLeSC/ODEX-FAIRDataPoint"
+title: "FAIR Data Point"
+version: "0.5"


### PR DESCRIPTION
should fix a syntax error with the CITATION.cff (date should not be a string). Also did some minor txt changes and yamllinted the whole deal.

Note that there is also a problem with CITATION.cff's schema validation (https://github.com/citation-file-format/schema/pull/2). The error only happens when there is an ORCID that ends in 'X' (which is allowed according to the ORCID standard, and which you happen to have), so I don't expect the citation generation on research-software.nl to start working immediately but at least we did everything correctly on our end.

Thanks,
-Jurriaan