### PR TITLE
CITATION.cff fix and automatic validation of your citation metadata

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,0 +1,19 @@
+name: cffconvert
+
+on:
+  push:
+    paths:
+      - CITATION.cff
+
+jobs:
+  validate:
+    name: "validate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repository
+        uses: actions/checkout@v2
+
+      - name: Check whether the citation metadata from CITATION.cff is valid
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,7 +23,7 @@ authors:
     given-names: Cunliang
     orcid: "https://orcid.org/0000-0002-1409-8358"
 
-cff-version: "1.0.3"
+cff-version: 1.2.0
 date-released: 2020-09-15
 doi: 10.5281/zenodo.1083951
 license: Apache-2.0


### PR DESCRIPTION
Hello!

We noticed that your CITATION.cff had a small issue and fixed it - possibly by just updating `cffversion` to 1.2.0.
In addition to the fix, this Pull Request automates validation of the CITATION.cff file using the [cffconvert GitHub Action](https://github.com/marketplace/actions/cffconvert). That way, it's a little bit easier to be robust against future changes to the `CITATION.cff` file.

BTW it's perfectly fine if you don't feel like accepting this Pull Request for whatever reason -- we just thought it might be helpful is all.

We found your repository using a partially automated workflow; if you have any questions about that, feel free to create an issue over at https://github.com/cffbots/filtering/issues/

On behalf of the cffbots team,
@abelsiqueira / @fdiblen / @jspaaks